### PR TITLE
Update the BeamPaint twins

### DIFF
--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -1,73 +1,102 @@
-local json = require("json")
 
 local M = {}
+
 M.dependencies = {"ui_imgui"}
+
 local im = ui_imgui
 
 M.markedReady = false
 M.alreadySent = {}
 M.incompleteTextureData = {}
 M.texMap = {}
-M.showReloadButton = false
+M.inVehicleConfigMenu = false
+M.inVehiclePaintMenu = false
+M.singlePlayer = true
+M.waitingForRole = {}
+M.waitingForLivery = {}
+M.waitingForSetLivery = {}
 
 -- TODO: Currently it assumes all packets arrive in order.
 --       This should always be true, but we should probably
 --       account for it anyway!
 local function BP_receiveTextureData(json_data)
-    print("Received texture data from server...")
-    print(json_data)
-    local data = json.decode(json_data)
-    dump(data)
-    print("Data size: " .. #data.raw)
+    local data = jsonDecode(json_data)
     local tid = data.target_id
     local raw = mime.unb64(data.raw)
     M.incompleteTextureData[tid] = M.incompleteTextureData[tid] or ""
-    -- for i=1,#data.raw do
-    --     M.incompleteTextureData[tid][data.raw_offset + i] = data.raw[i]
-    -- end
     M.incompleteTextureData[tid] = M.incompleteTextureData[tid] .. raw
-    print("Total so far: " .. #M.incompleteTextureData[tid])
     TriggerServerEvent("BP_textureDataReceived", "" .. tid)
 end
-AddEventHandler("BP_receiveTextureData", BP_receiveTextureData)
 
-local function BP_markTextureComplete(json_data)
-    print("Received texture complete status from server...")
-    local data = json.decode(json_data)
-    local tid = data.target_id
-    print("Writing data to a file...")
-    local out = io.open("vehicles/common/" .. tid .. ".png", "wb")
-    out:write(M.incompleteTextureData[tid])
-    out:flush()
-    out:close()
-    print("Written to file!")
-    M.incompleteTextureData[tid] = ""
-
+local function applyLiveryAttempt()
+    local tid = table.remove(M.waitingForLivery, 1)
     local objid = MPVehicleGE.getGameVehicleID(tid)
-    M.texMap[objid] = tid
-    be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tid .. ".png\")")
-end
-AddEventHandler("BP_markTextureComplete", BP_markTextureComplete)
-
-local function onUpdate(dtSim, dtRaw)
-    if M.markedReady == false and worldReadyState >= 2 then
-        M.markedReady = true
-        TriggerServerEvent("BP_clientReady", "")
-        print("Marked myself as ready")
+    if objid then
+        M.texMap[objid] = tid
+        be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tid .. ".png\")")
+    else
+        table.insert(M.waitingForLivery, tid)
     end
 end
 
-local function setLiveryUsed(objid, vehName)
+local function BP_markTextureComplete(json_data)
+    print("Received texture complete status from server...")
+    local data = jsonDecode(json_data)
+    local tid = data.target_id
+    print("Writing data to a file...")
+    local out = io.open("vehicles/common/" .. tid .. ".png", "wb")
+    if out then
+        out:write(M.incompleteTextureData[tid])
+        out:flush()
+        out:close()
+        print("Written to file!")
+    else
+        print("Could not write to file!")
+    end
+    M.incompleteTextureData[tid] = ""
+    table.insert(M.waitingForLivery, tid)
+end
+
+local function setLiveryUsedAttempt(objid, vehName)
     if MPVehicleGE.isOwn(objid) then
         if M.alreadySent[objid] ~= nil and M.alreadySent[objid].prevVehName == vehName then
-            be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. M.texMap[objid] .. ".png\")")
+            local tid = M.texMap[objid]
+            if tid then
+                be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tid .. ".png\")")
+                return false
+            end
         else
             M.alreadySent[objid] = { prevVehName = vehName }
             local serverid = MPVehicleGE.getServerVehicleID(objid)
-            TriggerServerEvent("BP_setLiveryUsed", "" .. serverid .. ";" .. vehName)
+            if serverid then
+                -- We messed up the name on our backend :(
+                if vehName == "us_semi" then
+                    vehName = "tseries"
+                end
+                TriggerServerEvent("BP_setLiveryUsed", "" .. serverid .. ";" .. vehName)
+                return false
+            end
         end
     else
-        be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. M.texMap[objid] .. ".png\")")
+        local tid = M.texMap[objid]
+        if tid then
+            be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tid .. ".png\")")
+            return false
+        end
+    end
+    return true
+end
+
+local function setLiveryUsed(objid, vehName)
+    if M.singlePlayer then
+        -- We are in singleplayer!
+        print("loading livery from " .. "/vehicles/common/" .. vehName .. ".png")
+        if FS:fileExists("/vehicles/common/" .. vehName .. ".png") then
+            be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. vehName .. ".png\", true)")
+        end
+    else
+        -- We are in multiplayer!
+        table.insert(M.waitingForSetLivery, { objid = objid, vehName = vehName })
     end
 end
 
@@ -80,38 +109,137 @@ local function reloadLivery()
     end
 end
 
-local function BP_setPremium(json_data)
-    local data = json.decode(json_data)
+local function setPremiumAttempt(data)
     local role = "BP_PREMIUM"
-    if data.isDev then role = "BP_DEV" end
-    MPVehicleGE.setVehicleRole(data.tid, role)
+    if data.isAdmin then
+        role = "BP_ADMIN"
+    end
+    if MPVehicleGE.setVehicleRole(data.tid, role, 0) == 0 then
+        return true
+    end
+    return false
 end
-AddEventHandler("BP_setPremium", BP_setPremium)
+
+local function BP_setPremium(json_data)
+    local data = jsonDecode(json_data)
+    if MPVehicleGE.setPlayerRole then
+        local tmp = split(data.tid, "-")
+        local pid = tonumber(tmp[1])
+
+        local role = "BeamPaint Premium"
+        local roleShort = "BP Premium"
+        local roleR, roleG, roleB = 193, 87, 217
+        if data.isAdmin then
+            role = "BeamPaint Admin"
+            roleShort = "BP Admin"
+            roleR, roleG, roleB = 235, 64, 52
+        end
+        print("setPlayerRole:")
+        dump(MPVehicleGE.setPlayerRole(pid, role, roleShort, roleR, roleG, roleB))
+    else
+        table.insert(M.waitingForRole, data)
+    end
+end
+
+local function BP_informSignup()
+    guihooks.trigger(
+        "ConfirmationDialogOpen",
+        "BeamPaint: You need to register!",
+        "Please register at <b>beampaint.com/account</b>!<br>If you have already registered and still encounter this issue, please read the <b>Quickstart</b> guide.",
+        "Understood!",
+        "extensions.BeamPaint.closeInformSignup()"
+    )
+end
+
+local function closeInformSignup()
+    guihooks.trigger("ConfirmationDialogClose", "BeamPaint: You need to register!")
+end
 
 local function init()
-    MPVehicleGE.createRole("BP_DEV", "BeamPaint DEVELOPER", "BP DEV", 235, 64, 52)
-    MPVehicleGE.createRole("BP_PREMIUM", "BeamPaint PREMIUM", "BP PREMIUM", 193, 87, 217)
-end
-
-local function onUiChangedState(state)
-    M.showReloadButton = state == "menu.vehicleconfig.parts"
-end
-
-local function onUpdate(dt)
-    if M.showReloadButton then
-        if im.Begin("", im.BoolPtr(true), im.WindowFlags_AlwaysAutoResize + im.WindowFlags_NoDecoration) then
-            if im.Button("Reload Livery") then
-                reloadLivery()
+    if MPCoreNetwork then
+        if MPCoreNetwork.isMPSession() == true then
+            M.singlePlayer = false
+            AddEventHandler("BP_receiveTextureData", BP_receiveTextureData)
+            AddEventHandler("BP_markTextureComplete", BP_markTextureComplete)
+            AddEventHandler("BP_setPremium", BP_setPremium)
+            AddEventHandler("BP_informSignup", BP_informSignup)
+            if not MPVehicleGE.setPlayerRole then
+                MPVehicleGE.createRole("BP_ADMIN", "BeamPaint Admin", "BP Admin", 235, 64, 52)
+                MPVehicleGE.createRole("BP_PREMIUM", "BeamPaint Premium", "BP Premium", 193, 87, 217)
             end
         end
     end
 end
 
+local function onUiChangedState(state)
+    M.inVehicleConfigMenu = state == "menu.vehicleconfig.parts"
+    M.inVehiclePaintMenu = state == "menu.vehicleconfig.color"
+end
+
+local function onUpdate(dt)
+    if M.markedReady == false and worldReadyState >= 2 then
+        M.markedReady = true
+        if not M.singlePlayer then
+            TriggerServerEvent("BP_clientReady", "")
+        end
+    end
+    if #M.waitingForRole > 0 then
+        local data = table.remove(M.waitingForRole, 1)
+        if setPremiumAttempt(data) then
+            table.insert(M.waitingForRole, data)
+        end
+    end
+    if #M.waitingForLivery > 0 then
+        applyLiveryAttempt()
+    end
+    if #M.waitingForSetLivery > 0 then
+        local data = table.remove(M.waitingForSetLivery, 1)
+        if setLiveryUsedAttempt(data.objid, data.vehName) then
+            table.insert(M.waitingForSetLivery, data)
+        end
+    end
+    if M.inVehiclePaintMenu then
+        -- Update the current player vehicle paint data
+        M.updatePlayerVehiclePaint(be:getPlayerVehicleID(0))
+    end
+    if M.inVehicleConfigMenu then
+        -- Show the "Reload livery" UI
+        if im.Begin("BeamPaint", im.BoolPtr(true), im.WindowFlags_AlwaysAutoResize) then
+            if im.Button("Reload Livery") then
+                reloadLivery()
+            end
+            if M.singlePlayer then
+                im.Separator()
+                im.Text("Liveries are loaded from /vehicle/common/<vehName>.png!")
+                im.Text("If you want to preview a livery, simply put it in there with the right name and hit \"Reload Livery\".")
+                local vehName = be:getPlayerVehicle(0):getField("JBeam", 0)
+                im.Text("For the current vehicle: \"/vehicle/common/" .. vehName .. ".png\"")
+                if im.Button("Open folder...") then
+                    Engine.Platform.exploreFolder("/vehicles/common/")
+                end
+            else
+                -- TODO: Show current livery?
+            end
+        end
+    end
+end
+
+local function updatePlayerVehiclePaint(vehID)
+    local veh = be:getObjectByID(vehID)
+    local r = veh.color.x
+    local g = veh.color.y
+    local b = veh.color.z
+    veh:queueLuaCommand("extensions.BeamPaint.updateCurrentPaint(" .. r .. "," .. g .. "," .. b ..")")
+end
+
 M.onExtensionLoaded = init
-M.onUpdate = onUpdate
 M.setLiveryUsed = setLiveryUsed
 M.reloadLivery = reloadLivery
 M.onUiChangedState = onUiChangedState
 M.onUpdate = onUpdate
+M.closeInformSignup = closeInformSignup
+M.updatePlayerVehiclePaint = updatePlayerVehiclePaint
+
+M.BP_informSignup = BP_informSignup
 
 return M

--- a/lua/vehicle/extensions/auto/BeamPaint.lua
+++ b/lua/vehicle/extensions/auto/BeamPaint.lua
@@ -1,20 +1,71 @@
+
 local htmlTexture = require("htmlTexture")
 
 local M = {}
+M.isRightSkin = false
+M.isInit = false
+M.lastPaint = {}
+M.currentPaint = {}
 
 local function initLivery()
-    htmlTexture.create("@dynamic_livery", "local://local/vehicles/common/dynamic_livery.html", 1024, 1024, 0, "manual")
+    htmlTexture.create("@dynamic_livery", "local://local/vehicles/common/dynamic_livery.html", 2048, 2048, 0, "manual")
     htmlTexture.call("@dynamic_livery", "init")
-    obj:queueGameEngineLua("extensions.BeamPaint.setLiveryUsed(" .. obj:getID() .. ", \"" .. v.config.mainPartName .. "\")")
+    local modelName = v.config.model or v.config.mainPartName
+    obj:queueGameEngineLua("extensions.BeamPaint.setLiveryUsed(" .. obj:getID() .. ", \"" .. modelName .. "\")")
 end
 
-local function updateLivery(src)
+local function isRightSkin(partsTree)
+    for key, part in pairs(partsTree) do
+        if key == "paint_design" or key == "skin_lbe" then
+            print(part.chosenPartName)
+            if part.chosenPartName == "global_skin_dynamic" or part.chosenPartName == "global_skin_dynamic_lbe" then
+                return true
+            end
+        end
+        if part.children then
+            if isRightSkin(part.children) then return true end
+        end
+    end
+    return false
+end
+
+local function onExtensionLoaded()
+    print("BeamPaint VE loaded!")
+    -- M.isRightSkin = v.config.partsTree.paint_design == "global_skin_dynamic"
+    -- M.isRightSkin = M.isRightSkin or v.config.partsTree.skin_lbe == "global_skin_dynamic_lbe"
+    M.isRightSkin = isRightSkin(v.config.partsTree.children)
+    if M.isRightSkin then
+        initLivery()
+        M.isInit = true
+        obj:queueGameEngineLua("extensions.BeamPaint.updatePlayerVehiclePaint(" .. obj:getID() .. ")")
+    end
+end
+
+local function updateLivery(src, needsGammaCorrection)
     local data = {}
-    data.src = src;
+    data.src = src
+    data.needsGammaCorrection = needsGammaCorrection
     htmlTexture.call("@dynamic_livery", "updateLivery", data)
 end
 
-M.onExtensionLoaded = initLivery
+local function updateGFX(dt)
+    if M.isRightSkin then
+        if M.lastPaint ~= M.currentPaint and M.isInit then
+            M.lastPaint = M.currentPaint
+            local data = M.currentPaint
+            htmlTexture.call("@dynamic_livery", "updatePaint", data)
+        end
+    end
+end
+
+local function updateCurrentPaint(r, g, b)
+    M.currentPaint = {}
+    M.currentPaint.baseColor = { r, g, b }
+end
+
+M.onExtensionLoaded = onExtensionLoaded
 M.updateLivery = updateLivery
+M.updateGFX = updateGFX
+M.updateCurrentPaint = updateCurrentPaint
 
 return M


### PR DESCRIPTION
Recovered from a current BeamPaint.zip provided to me by Luuk, tweaked for various aspects:
Remove overwrites of BeamMP global functions via use of an M.singlePlayer flag
Handles existing in a player's mods folder and will not crash BeamMP now
Remove JSON require, instead of json.decode now use jsonDecode
Some nil check and minor cleanup